### PR TITLE
Centralise contributors

### DIFF
--- a/site/content/guide/index.md
+++ b/site/content/guide/index.md
@@ -38,25 +38,6 @@ sitemap:
   priority: 1.0
 author:
   - John Coleman
-creators:
-  - name: John Coleman
-    image: https://media.licdn.com/dms/image/v2/D4E03AQGlxycsyUPltg/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1676027893027?e=1756944000&v=beta&t=N8SWmvidRGpSczzO4xHubCF92V2YX-WyQY9JSZEE160
-    url: https://www.linkedin.com/in/johnanthonycoleman/
-contributors:
-  - name: Martin Hinshelwood
-    gravatarHash: a9a55b4384e0420e376f441384d0c13fdadb9d39e72892ac60c3e89c3079d10d
-    githubUsername: mrhinsh
-    url: https://nkdagility.com/company/people/martin-hinshelwood/
-  - name: Jim Benson
-    url: https://www.linkedin.com/in/jimbenson/
-  - name: Magdalena Firlit
-  - name: Michael Forni
-  - name: Christian Neverdal
-  - name: Nader Talai
-  - name: Steve Tendon
-  - name: Nigel Thurlow
-    url: https://www.linkedin.com/in/nigelthurlow/
-    image: https://media.licdn.com/dms/image/v2/D5603AQFUHK7rTaUzFQ/profile-displayphoto-shrink_400_400/B56ZVDywj0GoAk-/0/1740599134781?e=1756944000&v=beta&t=kHegE9bZMJXxLJ0zKbcr6kaaGSohFQ7etiLpFxeZsrs
 ---
 
 TBA

--- a/site/data/contributions.yml
+++ b/site/data/contributions.yml
@@ -1,0 +1,87 @@
+# Contributions Data
+# This file contains information about all contributors to the Open Guide to Kanban
+
+# All contributors in a flat list
+- name: John Coleman
+  image: https://media.licdn.com/dms/image/v2/D4E03AQGlxycsyUPltg/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1676027893027?e=1756944000&v=beta&t=N8SWmvidRGpSczzO4xHubCF92V2YX-WyQY9JSZEE160
+  url: https://www.linkedin.com/in/johnanthonycoleman/
+  contributions:
+    - creator
+    - author
+  role: creator
+  founding: true
+  weight: 1
+- name: Martin Hinshelwood
+  gravatarHash: a9a55b4384e0420e376f441384d0c13fdadb9d39e72892ac60c3e89c3079d10d
+  githubUsername: mrhinsh
+  url: https://nkdagility.com/company/people/martin-hinshelwood/
+  contributions:
+    - technical
+    - review
+    - contributor
+  role: contributor
+  founding: true
+
+- name: Jim Benson
+  url: https://www.linkedin.com/in/jimbenson/
+  contributions:
+    - review
+    - advisor
+    - contributor
+  role: contributor
+  founding: true
+
+- name: Magdalena Firlit
+  contributions:
+    - review
+    - contributor
+  role: contributor
+  founding: true
+
+- name: Michael Forni
+  url: https://www.linkedin.com/in/Michaelforni/
+  contributions:
+    - review
+    - contributor
+  role: contributor
+  founding: true
+
+- name: Christian Neverdal
+  contributions:
+    - review
+    - contributor
+  role: contributor
+  founding: true
+
+- name: Nader Talai
+  contributions:
+    - review
+    - contributor
+  role: contributor
+  founding: true
+
+- name: Steve Tendon
+  contributions:
+    - review
+    - contributor
+  role: contributor
+  founding: true
+
+- name: Nigel Thurlow
+  url: https://www.linkedin.com/in/nigelthurlow/
+  image: https://media.licdn.com/dms/image/v2/D5603AQFUHK7rTaUzFQ/profile-displayphoto-shrink_400_400/B56ZVDywj0GoAk-/0/1740599134781?e=1756944000&v=beta&t=kHegE9bZMJXxLJ0zKbcr6kaaGSohFQ7etiLpFxeZsrs
+  contributions:
+    - review
+    - contributor
+  role: contributor
+  weight: 2
+  founding: true
+
+- name: Rikard Skelander
+  url: https://www.linkedin.com/in/rikardskelander/
+  githubUsername: skelander
+  contributions:
+    - review
+    - contributor
+  role: contributor
+  founding: true

--- a/site/data/contributions.yml
+++ b/site/data/contributions.yml
@@ -40,6 +40,7 @@
 
 - name: Michael Forni
   url: https://www.linkedin.com/in/Michaelforni/
+  githubUsername: Michaelforni
   contributions:
     - review
     - contributor

--- a/site/layouts/_partials/JSON-LD/creativework.html
+++ b/site/layouts/_partials/JSON-LD/creativework.html
@@ -1,6 +1,15 @@
 {{- $baseURL := .Site.BaseURL -}}
 {{- $siteURL := .Site.Params.siteProdUrl | default $baseURL -}}
 {{- $pageURL := printf "%s%s" $siteURL .RelPermalink -}}
+{{- $isDefaultLanguage := eq .Site.Language.Lang .Site.Home.Language.Lang -}}
+{{- $isTranslatedPage := not $isDefaultLanguage -}}
+
+{{- $defaultLang := .Site.Home.Language.Lang | default "en" -}}
+{{- $currentPageDefaultLang := .Site.GetPage (printf "/%s%s" $defaultLang .File.Path) -}}
+{{- if not $currentPageDefaultLang -}}
+  {{- $currentPageDefaultLang = .Site.Sites.Default.GetPage .File.Path -}}
+{{- end -}}
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -11,9 +20,9 @@
   "url": {{ $pageURL }},
   "datePublished": "{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}",
   "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}",
-  {{- $allCreators := (partial "functions/get-participants" .) }}
+  {{- $foundingContributors := where .Site.Data.contributions "founding" true -}}
   "author": [
-    {{- range $index, $creator := $allCreators -}}
+    {{- range $index, $creator := $foundingContributors -}}
     {{- if $index }},{{ end }}
     {
       "@type": "Person",

--- a/site/layouts/_partials/components/guide/guide-author.html
+++ b/site/layouts/_partials/components/guide/guide-author.html
@@ -1,4 +1,4 @@
-<span class="author-item me-3">
+<span class="author-item me-3" title="{{ .name }} - {{ .weight }}">
   {{- if .gravatarHash }}
     <img src="https://www.gravatar.com/avatar/{{ .gravatarHash }}?s=24&d=mp" alt="{{ .name }}" aria-label="Profile picture of {{ .name }}" class="author-avatar rounded-circle me-1" style="width: 24px; height: 24px; object-fit: cover;" />
   {{- else if .githubUsername }}

--- a/site/layouts/_partials/components/guide/guide-contributors.html
+++ b/site/layouts/_partials/components/guide/guide-contributors.html
@@ -1,11 +1,8 @@
-<!-- Authors from creators list -->
-{{- $defaultLang := .Site.Home.Language.Lang | default "en" -}}
-{{- $currentPageDefaultLang := .Site.GetPage (printf "/%s%s" $defaultLang .File.Path) -}}
-{{- if not $currentPageDefaultLang -}}
-  {{- $currentPageDefaultLang = .Site.Sites.Default.GetPage .File.Path -}}
-{{- end -}}
-
-{{ $contributors := $currentPageDefaultLang.Params.contributors }}
+{{ $contributors := .Params.contributors }}
+{{ if not $contributors }}
+  {{- $contributors = where .Site.Data.contributions "founding" true -}}
+  {{- $contributors = where $contributors "role" "contributor" -}}
+{{ end }}
 {{ if $contributors }}
   <div class="content-authors mt-3">
     <div class="row">

--- a/site/layouts/_partials/components/guide/guide-contributors.html
+++ b/site/layouts/_partials/components/guide/guide-contributors.html
@@ -10,7 +10,7 @@
         <span class="text-muted me-2">Contributors(s):</span>
       </div>
       <div class="col-12 col-md-10">
-        {{ range sort $contributors "name" }}
+        {{ range sort $contributors "weight" "desc" }}
           {{ partial "components/guide/guide-author.html" . }}
         {{ end }}
       </div>

--- a/site/layouts/_partials/components/guide/guide-creators.html
+++ b/site/layouts/_partials/components/guide/guide-creators.html
@@ -1,11 +1,8 @@
-<!-- Authors from creators list -->
-{{- $defaultLang := .Site.Home.Language.Lang | default "en" -}}
-{{- $currentPageDefaultLang := .Site.GetPage (printf "/%s%s" $defaultLang .File.Path) -}}
-{{- if not $currentPageDefaultLang -}}
-  {{- $currentPageDefaultLang = .Site.Sites.Default.GetPage .File.Path -}}
-{{- end -}}
-
-{{ $creators := $currentPageDefaultLang.Params.creators }}
+{{ $creators := .Params.creators }}
+{{ if not $creators }}
+  {{- $creators = where .Site.Data.contributions "founding" true -}}
+  {{- $creators = where $creators "role" "creator" -}}
+{{ end }}
 {{ if $creators }}
   <div class="content-authors mt-3">
     <div class="row">
@@ -13,7 +10,7 @@
         <span class="text-muted me-2">Creator(s):</span>
       </div>
       <div class="col-12 col-md-10">
-        {{ range sort $creators "name" }}
+        {{ range sort $creators "weight" }}
           {{ partial "components/guide/guide-author.html" . }}
         {{ end }}
       </div>

--- a/site/layouts/_partials/components/translations/official-version.html
+++ b/site/layouts/_partials/components/translations/official-version.html
@@ -1,6 +1,6 @@
 {{- $englishSite := index (where .Site.Sites "Language.Lang" "en") 0 }}
 {{- $guidePage := $englishSite.GetPage "/guide" }}
-{{- $allCreators := (partial "functions/get-participants" $guidePage) }}
+{{- $foundingContributors := where .Site.Data.contributions "founding" true -}}
 
 <h2 class="mb-3">{{ i18n "download_official_version" . }}</h2>
 
@@ -24,9 +24,9 @@
       </h6>
       <p class="card-text text-muted mb-3">
         <small>{{ i18n "download_table_written_by" . }}:</small><br />
-        {{- range $index, $creator := $allCreators }}
+        {{- range $index, $creator := $foundingContributors }}
           {{- if $index }},{{ end }}
-          {{- if gt (len $allCreators) 1 }}{{ if eq $index (sub (len $allCreators) 1) }}&nbsp;{{ end }}{{ end }}
+          {{- if gt (len $foundingContributors) 1 }}{{ if eq $index (sub (len $foundingContributors) 1) }}&nbsp;{{ end }}{{ end }}
           <a href="{{ $creator.url }}" class="text-decoration-none">{{ $creator.name }}<i class="fa-solid fa-external-link-alt ms-1" style="font-size: 0.6em;"></i>
           </a>
         {{- end }}
@@ -57,9 +57,9 @@
       {{ i18n "download_official_current_version" . }}
     </div>
     <div class="col-md-4">
-      {{- range $index, $creator := $allCreators }}
+      {{- range $index, $creator := $foundingContributors }}
         {{- if $index }},{{ end }}
-        {{- if gt (len $allCreators) 1 }}{{ if eq $index (sub (len $allCreators) 1) }}&nbsp;{{ end }}{{ end }}
+        {{- if gt (len $foundingContributors) 1 }}{{ if eq $index (sub (len $foundingContributors) 1) }}&nbsp;{{ end }}{{ end }}
         <a href="{{ $creator.url }}" class="text-decoration-none"> {{ $creator.name }}<i class="fa-solid fa-external-link-alt ms-1" style="font-size: 0.6em;"></i>
         </a>
       {{- end }}

--- a/site/layouts/_partials/components/versions/version-card.html
+++ b/site/layouts/_partials/components/versions/version-card.html
@@ -36,7 +36,12 @@ Parameters: - page: The Hugo page object to render - isLatest: (optional) Boolea
 
         <div class="d-flex flex-wrap gap-2 mb-3">
           {{/* Display creators */}}
-          {{ range .Params.creators }}
+          {{ $creators := .Params.creators }}
+          {{ if not $creators }}
+            {{- $creators = where .Site.Data.contributions "founding" true -}}
+            {{- $creators = where $creators "role" "creator" -}}
+          {{ end }}
+          {{ range $creators }}
             <span class="badge bg-primary">
               {{ if .url }}
                 <a href="{{ .url }}" target="_blank" rel="noopener" class="text-white text-decoration-none">
@@ -50,7 +55,12 @@ Parameters: - page: The Hugo page object to render - isLatest: (optional) Boolea
           {{ end }}
 
           {{/* Display contributors */}}
-          {{ range .Params.contributors }}
+          {{ $contributors := .Params.contributors }}
+          {{ if not $contributors }}
+            {{- $contributors = where .Site.Data.contributions "founding" true -}}
+            {{- $contributors = where $contributors "role" "contributor" -}}
+          {{ end }}
+          {{ range $contributors }}
             <span class="badge bg-secondary">
               {{ if .url }}
                 <a href="{{ .url }}" target="_blank" rel="noopener" class="text-white text-decoration-none">
@@ -63,19 +73,6 @@ Parameters: - page: The Hugo page object to render - isLatest: (optional) Boolea
             </span>
           {{ end }}
 
-          {{/* Display translators if this is a translated page */}}
-          {{ range .Params.translators }}
-            <span class="badge bg-info">
-              {{ if .url }}
-                <a href="{{ .url }}" target="_blank" rel="noopener" class="text-white text-decoration-none">
-                  {{ .name }}
-                  <i class="fa-solid fa-external-link-alt ms-1" style="font-size: 0.6em;"></i>
-                </a>
-              {{ else }}
-                {{ .name }}
-              {{ end }}
-            </span>
-          {{ end }}
         </div>
 
         {{/* Language buttons section */}}


### PR DESCRIPTION
This pull request introduces a significant refactor to how contributors and creators are managed and displayed across the site. The changes centralize contributor data into a new `site/data/contributions.yml` file, replacing inline definitions, and improve the logic for rendering creators and contributors dynamically. Additionally, the logic for handling translated pages and default languages has been enhanced for better maintainability.

### Contributor and Creator Data Refactor:
* Moved all contributor and creator information to a new `site/data/contributions.yml` file for centralized management. This includes details such as names, roles, URLs, and contributions.
* Updated `site/content/guide/index.md` to remove inline creator and contributor definitions, relying instead on the centralized contributions data.

### Rendering Improvements:
* Updated templates (e.g., `guide-author.html`, `guide-contributors.html`, `guide-creators.html`, and `version-card.html`) to dynamically fetch creators and contributors from the centralized data, with fallback logic for missing parameters. Sorting by weight or role is now supported. [[1]](diffhunk://#diff-1332cf588ab311b263cceb74d36a665f12528568c4ec2bc198fcc596994f53e6L1-R1) [[2]](diffhunk://#diff-55757639d99fe6fc0beb7f0c99ef297a60f2faf592314300d32a840df94fab0eL1-R13) [[3]](diffhunk://#diff-afaa3db0c4f1e6deaa6db480dda0e9092aaf90c274034f5cd715e7a92b103aefL1-R13) [[4]](diffhunk://#diff-0c21e3b7816788512d8949bf93e1fa9172a09347eaec9b32bb4db6d340e6df64L39-R44) [[5]](diffhunk://#diff-0c21e3b7816788512d8949bf93e1fa9172a09347eaec9b32bb4db6d340e6df64L53-R63)
* Removed the translators section from `version-card.html` to simplify the layout.

### Schema and Metadata Enhancements:
* Enhanced the `JSON-LD` metadata in `creativework.html` to use the new contributions data, ensuring accurate attribution for founding contributors. [[1]](diffhunk://#diff-7f6d33d84a4db98c12339663eb0ca79f899bbcfbcc9b11144bbb77be7bff7563R4-R12) [[2]](diffhunk://#diff-7f6d33d84a4db98c12339663eb0ca79f899bbcfbcc9b11144bbb77be7bff7563L14-R25)
* Improved logic for handling translated pages and default languages in `creativework.html` for better compatibility.

### Official Version Page Updates:
* Updated the contributors' display logic in `official-version.html` to use the centralized contributions data, ensuring consistency with other templates. [[1]](diffhunk://#diff-d6c7322d3b3fe275a2a6a3be328c80e5311f5dc67cc59bf5b12001bdc8a8e802L3-R3) [[2]](diffhunk://#diff-d6c7322d3b3fe275a2a6a3be328c80e5311f5dc67cc59bf5b12001bdc8a8e802L27-R29) [[3]](diffhunk://#diff-d6c7322d3b3fe275a2a6a3be328c80e5311f5dc67cc59bf5b12001bdc8a8e802L60-R62)