### PR TITLE
Base url

### DIFF
--- a/site/hugo.preview.yaml
+++ b/site/hugo.preview.yaml
@@ -1,4 +1,4 @@
-baseURL: https://red-pond-0d8225910-preview.centralus.2.azurestaticapps.net
+baseURL: /
 Environment: "preview"
 minifyOutput: true
 

--- a/site/hugo.production.yaml
+++ b/site/hugo.production.yaml
@@ -1,4 +1,4 @@
-baseURL: https://kanbanguides.org
+baseURL: /
 Environment: "production"
 minifyOutput: true
 

--- a/site/layouts/_partials/components/translations/community-translations.html
+++ b/site/layouts/_partials/components/translations/community-translations.html
@@ -20,9 +20,8 @@
   {{- end }}
 {{- else }}
   {{- $productionLanguagesUrl := printf "%slanguages.json?v=%d" .Site.Params.productionSiteUrl now.Unix }}
-  {{- $productionLanguagesResponse := resources.GetRemote $productionLanguagesUrl }}
-  {{- if $productionLanguagesResponse }}
-    {{- $productionLanguagesData = $productionLanguagesResponse | transform.Unmarshal }}
+  {{- with try (resources.GetRemote $productionLanguagesUrl) }}
+    {{- $productionLanguagesData = . | transform.Unmarshal }}
   {{- end }}
 {{- end }}
 

--- a/site/layouts/_partials/components/translations/community-translations.html
+++ b/site/layouts/_partials/components/translations/community-translations.html
@@ -21,7 +21,11 @@
 {{- else }}
   {{- $productionLanguagesUrl := printf "%slanguages.json?v=%d" .Site.Params.productionSiteUrl now.Unix }}
   {{- with try (resources.GetRemote $productionLanguagesUrl) }}
-    {{- $productionLanguagesData = . | transform.Unmarshal }}
+    {{ with .Err }}
+      {{ warnf "Error fetching production languages: %s" . }}
+    {{ else }}
+      {{- $productionLanguagesData = .Value | transform.Unmarshal }}
+    {{ end }}
   {{- end }}
 {{- end }}
 

--- a/site/layouts/_partials/components/translations/preview-translations.html
+++ b/site/layouts/_partials/components/translations/preview-translations.html
@@ -37,7 +37,7 @@
       {{ with .Err }}
         {{ warnf "Error fetching production languages: %s" . }}
       {{ else }}
-        {{- $productionLanguagesData = . | transform.Unmarshal }}
+        {{- $productionLanguagesData = .Value | transform.Unmarshal }}
         {{- if $productionLanguagesData.languages }}
           {{- range $productionLanguagesData.languages }}
             {{- $productionLanguageCodes = $productionLanguageCodes | append .code }}
@@ -61,7 +61,7 @@
       {{ with .Err }}
         {{ warnf "Error fetching production languages: %s" . }}
       {{ else }}
-        {{- $previewLanguagesData = . | transform.Unmarshal }}
+        {{- $previewLanguagesData = .Value | transform.Unmarshal }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/site/layouts/_partials/components/translations/preview-translations.html
+++ b/site/layouts/_partials/components/translations/preview-translations.html
@@ -33,12 +33,18 @@
   {{- else }}
     {{/* Load remote file in other environments */}}
     {{- with try (resources.GetRemote $productionLanguagesUrl) }}
-      {{- $productionLanguagesData = . | transform.Unmarshal }}
-      {{- if $productionLanguagesData.languages }}
-        {{- range $productionLanguagesData.languages }}
-          {{- $productionLanguageCodes = $productionLanguageCodes | append .code }}
+
+      {{ with .Err }}
+        {{ warnf "Error fetching production languages: %s" . }}
+      {{ else }}
+        {{- $productionLanguagesData = . | transform.Unmarshal }}
+        {{- if $productionLanguagesData.languages }}
+          {{- range $productionLanguagesData.languages }}
+            {{- $productionLanguageCodes = $productionLanguageCodes | append .code }}
+          {{- end }}
         {{- end }}
-      {{- end }}
+      {{ end }}
+
     {{- end }}
   {{- end }}
 
@@ -52,7 +58,11 @@
   {{- else }}
     {{/* Load remote file in other environments */}}
     {{- with try (resources.GetRemote $previewLanguagesUrl) }}
-      {{- $previewLanguagesData = . | transform.Unmarshal }}
+      {{ with .Err }}
+        {{ warnf "Error fetching production languages: %s" . }}
+      {{ else }}
+        {{- $previewLanguagesData = . | transform.Unmarshal }}
+      {{- end }}
     {{- end }}
   {{- end }}
 

--- a/site/layouts/_partials/components/translations/preview-translations.html
+++ b/site/layouts/_partials/components/translations/preview-translations.html
@@ -32,9 +32,8 @@
     {{- end }}
   {{- else }}
     {{/* Load remote file in other environments */}}
-    {{- $productionLanguagesResponse := resources.GetRemote $productionLanguagesUrl }}
-    {{- if $productionLanguagesResponse }}
-      {{- $productionLanguagesData = $productionLanguagesResponse | transform.Unmarshal }}
+    {{- with try (resources.GetRemote $productionLanguagesUrl) }}
+      {{- $productionLanguagesData = . | transform.Unmarshal }}
       {{- if $productionLanguagesData.languages }}
         {{- range $productionLanguagesData.languages }}
           {{- $productionLanguageCodes = $productionLanguageCodes | append .code }}
@@ -52,9 +51,8 @@
     {{- end }}
   {{- else }}
     {{/* Load remote file in other environments */}}
-    {{- $previewLanguagesResponse := resources.GetRemote $previewLanguagesUrl }}
-    {{- if $previewLanguagesResponse }}
-      {{- $previewLanguagesData = $previewLanguagesResponse | transform.Unmarshal }}
+    {{- with try (resources.GetRemote $previewLanguagesUrl) }}
+      {{- $previewLanguagesData = . | transform.Unmarshal }}
     {{- end }}
   {{- end }}
 

--- a/site/layouts/sitemap.xml
+++ b/site/layouts/sitemap.xml
@@ -19,12 +19,12 @@
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Language.LanguageCode }}"
-                href="{{ .Permalink }}"
+                href="{{ .Site.Params.siteProdUrl }}{{ .RelPermalink }}"
                 />{{ end }}
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Language.LanguageCode }}"
-                href="{{ .Permalink }}"
+                href="{{ .Site.Params.siteProdUrl }}{{ .RelPermalink }}"
                 />{{ end }}
   </url>
     {{- end -}}


### PR DESCRIPTION
This pull request updates the configuration and sitemap generation to improve URL handling for the production environment. The most important changes include modifying the `baseURL` in the production configuration file and updating the sitemap to use a parameterized production URL.

### Configuration updates:
* [`site/hugo.production.yaml`](diffhunk://#diff-b30079d21c29b4e42a159e2d01428365fa9bcb235876d733e39270eda77fd29bL1-R1): Changed the `baseURL` from a hardcoded URL (`https://kanbanguides.org`) to a relative root path (`/`) for better flexibility in deployment environments.

### Sitemap generation updates:
* [`site/layouts/sitemap.xml`](diffhunk://#diff-95fa58feb46619e32171e46c57eafc7861bc38495fb3a2950c5fe33c36e0697bL22-R27): Updated the `href` attributes in the sitemap to concatenate the `siteProdUrl` parameter with the relative permalink (`.RelPermalink`) instead of using `.Permalink`, ensuring consistent URL generation based on the production environment configuration.