### PR TITLE
Feedback christian neverdal

### DIFF
--- a/site/content/guide/index.md
+++ b/site/content/guide/index.md
@@ -38,7 +38,7 @@ sitemap:
   priority: 1.0
 ---
 
-This work, Open Guide to Kanban, is an adaptation of the Kanban Guide (May 2025 version) from [https://kanbanguides.org/history/kanban-guide-2025/](https://kanbanguides.org "previous"), which is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). The original guide is © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc. Changes were made to the original. Licensed under CC BY-SA 4.0: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/). _Portions highlighted in italic are © 2025_ Orderly Disruption Limited, licensed under CC BY-SA 4.0. All other content is from © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc., also licensed under CC BY-SA 4.0.
+This work, Open Guide to Kanban, is an adaptation of the [Kanban Guide (May 2025 version)](https://kanbanguides.org/history/kanban-guide-2025/), which is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). The original guide is © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc. Changes were made to the original. Licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). _Portions highlighted in italic are © 2025_ Orderly Disruption Limited, licensed under CC BY-SA 4.0. All other content is from © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc., also licensed under CC BY-SA 4.0.
 
 ## Preface
 

--- a/site/content/guide/index.md
+++ b/site/content/guide/index.md
@@ -33,14 +33,12 @@ mainfont: "Times New Roman"
 sansfont: "Arial"
 monofont: "Courier New"
 guide_whatis: |
-  The Open Guide to Kanban is a practical, community-curated reference for using Kanban in knowledge work. It defines the essential practices, measures, and language for designing, running, and improving Kanban systems. Built on the foundations of the Kanban Guide (2025), this guide expands its applicability across industries and team contexts, while remaining open and adaptable. It is intended to support organisations seeking clarity, consistency, and effectiveness in how they manage the flow of value.
+  The [Open Guide to Kanban](/open-guide-to-kanban/) is a practical, community-curated reference for using Kanban in knowledge work. It defines the essential practices, measures, and language for designing, running, and improving Kanban systems. Built on the foundations of the [Kanban Guide (2025)](/history/kanban-guide-2025/), this guide expands its applicability across industries and team contexts, while remaining open and adaptable. It is intended to support organisations seeking clarity, consistency, and effectiveness in how they manage the flow of value.
 sitemap:
   priority: 1.0
-author:
-  - John Coleman
 ---
 
-This work, Open Guide to Kanban, is an adaptation of the Kanban Guide (May 2025 version) from [https://kanbanguides.org](https://kanbanguides.org), which is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). The original guide is © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc. Changes were made to the original. Licensed under CC BY-SA 4.0: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/). _Portions highlighted in italic are © 2025_ Orderly Disruption Limited, licensed under CC BY-SA 4.0. All other content is from © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc., also licensed under CC BY-SA 4.0.
+This work, Open Guide to Kanban, is an adaptation of the Kanban Guide (May 2025 version) from [https://kanbanguides.org/history/kanban-guide-2025/](https://kanbanguides.org "previous"), which is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). The original guide is © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc. Changes were made to the original. Licensed under CC BY-SA 4.0: [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/). _Portions highlighted in italic are © 2025_ Orderly Disruption Limited, licensed under CC BY-SA 4.0. All other content is from © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc., also licensed under CC BY-SA 4.0.
 
 ## Preface
 

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -15,7 +15,7 @@
   "routes": [
     {
       "route": "/english/",
-      "redirect": "/open-guide-to-kanban/",
+      "redirect": "/history/kanban-guide-2025/",
       "statusCode": 301
     },
     {


### PR DESCRIPTION
This pull request updates the `Open Guide to Kanban` to improve link clarity and accuracy, and modifies a redirect in the static web app configuration to align with the updated content structure.

### Content updates:
* Updated hyperlinks in `site/content/guide/index.md` to provide direct links to the `Open Guide to Kanban` and the `Kanban Guide (2025)` for better navigation and clarity. Adjusted licensing references to include updated URLs.

### Configuration updates:
* Changed the redirect in `staticwebapp.config.json` for the `/english/` route to point to `/history/kanban-guide-2025/` instead of `/open-guide-to-kanban/`, ensuring consistency with the revised content structure.


Co-authored-by: Christian Neverdal <flyrev@users.noreply.github.com>