### PR TITLE
🐛 fix(layout): correct homepage conditional for title rendering

### DIFF
--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -17,7 +17,7 @@
       })(window, document, "script", "dataLayer", "GTM-T2KD2BNT");
     </script>
     <!-- End Google Tag Manager -->
-    {{ if .Site.Home }}
+    {{ if .IsHome }}
       <title>{{ .Site.Title }} | {{ .Site.Params.Description }}</title>
     {{ else }}
       <title>{{ .Title }} | {{ .Site.Title }}</title>


### PR DESCRIPTION
- change .Site.Home to .IsHome to fix the homepage title rendering condition