### PR TITLE
New Translations Detection

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -59,6 +59,7 @@ outputs:
     - json
     - rss
     - languages
+    - translations
   section:
     - html
     - rss
@@ -75,6 +76,9 @@ outputFormats:
   json:
     mediaType: application/json
     baseName: pages
+  translations:
+    mediaType: application/json
+    baseName: translations
   languages:
     mediaType: application/json
     baseName: languages

--- a/site/layouts/_partials/functions/get-guide-translations-web.html
+++ b/site/layouts/_partials/functions/get-guide-translations-web.html
@@ -1,0 +1,122 @@
+{{- $guideVersionPage := . }}
+
+{{/* Extract version from the page object */}}
+{{ $guideVersion := "" }}
+{{ if $guideVersionPage.File }}
+  {{ $guideVersion = $guideVersionPage.File.Dir | strings.TrimSuffix "/" | path.Base }}
+{{ else }}
+  {{/* Fallback: extract from RelPermalink */}}
+  {{ $pathParts := split (strings.TrimSuffix $guideVersionPage.RelPermalink "/") "/" }}
+  {{ $guideVersion = index $pathParts (sub (len $pathParts) 1) }}
+{{ end }}
+
+{{/* Get all translations for this guide version page */}}
+{{ $allTranslations := $guideVersionPage.AllTranslations }}
+{{ $currentLang := $guideVersionPage.Language.Lang }}
+
+{{/* Collect all unique languages from both translations and PDFs */}}
+{{ $allLanguages := slice }}
+
+{{/* Add languages from online translations */}}
+{{ range $allTranslations }}
+  {{ $lang := .Language.Lang }}
+  {{ if not (in $allLanguages $lang) }}
+    {{ $allLanguages = $allLanguages | append $lang }}
+  {{ end }}
+{{ end }}
+
+{{/* Add languages from PDF resources */}}
+{{ $pdfPattern := "pdf/*.*.pdf" }}
+{{ $pdfResources := $guideVersionPage.Resources.Match $pdfPattern }}
+{{ range $pdfResources }}
+  {{/* Extract language from PDF filename - same logic as version-card.html */}}
+  {{ $pdfName := .Name }}
+  {{ $parts := split $pdfName "." }}
+  {{ if ge (len $parts) 3 }}
+    {{ $langFromPDF := index $parts (sub (len $parts) 2) }}
+    {{ if not (in $allLanguages $langFromPDF) }}
+      {{ $allLanguages = $allLanguages | append $langFromPDF }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{/* Create lookup maps for efficiency */}}
+{{ $translationsByLang := dict }}
+{{ range $allTranslations }}
+  {{ $lang := .Language.Lang }}
+  {{ $translationsByLang = merge $translationsByLang (dict $lang .) }}
+{{ end }}
+
+{{ $pdfsByLang := dict }}
+{{ range $pdfResources }}
+  {{ $pdfName := .Name }}
+  {{ $parts := split $pdfName "." }}
+  {{ if ge (len $parts) 3 }}
+    {{ $langFromPDF := index $parts (sub (len $parts) 2) }}
+    {{ $pdfsByLang = merge $pdfsByLang (dict $langFromPDF .) }}
+  {{ end }}
+{{ end }}
+
+{{/* Build final translations list */}}
+{{ $translations := slice }}
+{{ range $allLanguages }}
+  {{ $lang := . }}
+  {{ $langConfig := $guideVersionPage.Site.Language }}
+  {{ range $guideVersionPage.Site.Languages }}
+    {{ if eq .Lang $lang }}
+      {{ $langConfig = . }}
+    {{ end }}
+  {{ end }}
+  {{ $page := index $translationsByLang $lang }}
+  {{ $pdfResource := index $pdfsByLang $lang }}
+
+  {{/* Check if content is available for reading online */}}
+  {{ $hasContent := false }}
+  {{ if $page }}
+    {{ $hasContent = and $page.Content (ne (trim $page.Content " \n\r\t") "") }}
+  {{ end }}
+
+  {{/* Check if PDF is available and get PDF path */}}
+  {{ $hasPDF := ne $pdfResource nil }}
+  {{ $pdfPath := "" }}
+  {{ if $pdfResource }}
+    {{ $pdfPath = $pdfResource.RelPermalink }}
+  {{ end }}
+
+  {{/* Use page data if available, otherwise create fallback */}}
+  {{ $title := printf "Open Guide to Kanban %s" $guideVersion }}
+  {{ $relPermalink := "" }}
+  {{ $path := "" }}
+  {{ $date := now }}
+  {{ $description := printf "Guide available in %s" ($langConfig.LanguageName | default $lang) }}
+
+  {{ if $page }}
+    {{ $title = $page.Title }}
+    {{ $relPermalink = $page.RelPermalink }}
+    {{ $path = $page.Path }}
+    {{ $date = $page.Date }}
+    {{ $description = $page.Description | default $page.Summary }}
+  {{ end }}
+
+  {{ $translationInfo := dict
+    "Language" $lang
+    "LanguageName" ($langConfig.LanguageName | default $lang)
+    "Weight" ($langConfig.Weight | default 999)
+    "Title" $title
+    "RelPermalink" $relPermalink
+    "Path" $path
+    "Date" $date
+    "Description" $description
+    "Status" (cond (and $hasContent $hasPDF) "published" (cond $hasContent "online-only" (cond $hasPDF "pdf-only" "unavailable")))
+    "ReadOnline" (cond $hasContent true false)
+    "ReadPDF" (cond $hasPDF true false)
+    "PathPdf" $pdfPath
+  }}
+  {{ $translations = $translations | append $translationInfo }}
+{{ end }}
+
+{{/* Sort translations by weight and language */}}
+{{ $translations = sort $translations "Weight" }}
+
+{{/* Return just the translations array */}}
+{{ return $translations }}

--- a/site/layouts/_partials/functions/get-guide-translations.html
+++ b/site/layouts/_partials/functions/get-guide-translations.html
@@ -1,0 +1,82 @@
+{{/* Initialize slice with current language guide sections */}}
+{{ $sections := where .Site.Sections "Type" "guide" }}
+
+{{/* Flatten the slice if needed and remove duplicates */}}
+{{ $finalSections := slice }}
+{{ range $sections }}
+  {{ if reflect.IsSlice . }}
+    {{ range . }}
+      {{ $finalSections = $finalSections | append . }}
+    {{ end }}
+  {{ else }}
+    {{ $finalSections = $finalSections | append . }}
+  {{ end }}
+{{ end }}
+
+{{/* Remove duplicates by checking RelPermalink */}}
+{{ $uniqueSections := slice }}
+{{ $seen := slice }}
+{{ range $finalSections }}
+  {{ if not (in $seen .RelPermalink) }}
+    {{ $uniqueSections = $uniqueSections | append . }}
+    {{ $seen = $seen | append .RelPermalink }}
+  {{ end }}
+{{ end }}
+
+{{/* Transform to simplified structure with only useful information */}}
+{{ $guideInfo := slice }}
+{{ range $uniqueSections.ByWeight }}
+  {{/* Get all guide versions for this section */}}
+  {{ $sectionPages := where $.Site.RegularPages "Section" .Section }}
+  {{ $guidePages := where $sectionPages "Type" "guide" }}
+
+  {{/* Get the latest version for this section using the dedicated function */}}
+  {{ $latestVersionNumber := partial "functions/get-latest-version" . }}
+
+  {{/* Extract versions and create version info */}}
+  {{ $versions := slice }}
+  {{ range $guidePages.ByDate.Reverse }}
+    {{/* Extract version from URL path */}}
+    {{ $pathParts := split .RelPermalink "/" }}
+    {{ $version := "" }}
+    {{ range $pathParts }}
+      {{ if and (ne . "") (findRE `^\d{4}\.\d+$` .) }}
+        {{ $version = . }}
+        {{ break }}
+      {{ end }}
+    {{ end }}
+
+    {{ if $version }}
+      {{/* Get available translations for this version using the dedicated function */}}
+      {{ $versionTranslations := partial "functions/get-guide-translations-web" . }}
+
+      {{ $versionInfo := dict
+        "Version" $version
+        "Title" .Title
+        "Date" .Date
+        "RelPermalink" .RelPermalink
+        "Path" .Path
+        "Description" .Description
+        "Latest" (eq $version $latestVersionNumber)
+        "Translations" $versionTranslations
+      }}
+      {{ $versions = $versions | append $versionInfo }}
+    {{ end }}
+  {{ end }}
+
+  {{ $info := dict
+    "Title" .Title
+    "Path" .Path
+    "RelPermalink" .RelPermalink
+    "Section" .Section
+    "Type" .Type
+    "Weight" .Weight
+    "Description" .Description
+    "Versions" $versions
+    "LatestVersion" $latestVersionNumber
+  }}
+  {{ $guideInfo = $guideInfo | append $info }}
+{{ end }}
+
+{{/* Return the simplified guide information */}}
+{{ return $guideInfo }}

--- a/site/layouts/index.translations.json
+++ b/site/layouts/index.translations.json
@@ -1,0 +1,2 @@
+{{- $translations := partial "functions/get-guide-translations" . -}}
+{{- $translations | jsonify -}}


### PR DESCRIPTION
I really want all the translations, even PDF only, to be listed on the GuideHome... however, its been very difficult to get the list I want in the way that I want to render it.

- add translations output format in hugo.yaml
- create get-guide-translations-web.html for web translations
- create get-guide-translations.html for managing guide translations
- add index.translations.json to serve translations as JSON

Next is to use this to render the translations page with a proper list.

My idea is to show the latest version translation for each language.