### PR TITLE
Update go.mod

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -1,4 +1,4 @@
-module github.com/ScrumGuides/ScrumGuide-ExpansionPack/site
+module github.com/KanbanGuides/KanbanGuides/site
 
 go 1.24.5
 


### PR DESCRIPTION
This pull request updates the Go module path to reflect a new repository name. The change ensures that the module references are consistent with the new project branding.

* Updated the module path in `site/go.mod` from `github.com/ScrumGuides/ScrumGuide-ExpansionPack/site` to `github.com/KanbanGuides/KanbanGuides/site` to match the new repository name.