### PR TITLE
Update Lnaguage Skills

### DIFF
--- a/.agents/skills/guide.transcreate/SKILL.md
+++ b/.agents/skills/guide.transcreate/SKILL.md
@@ -56,7 +56,7 @@ Edit `site/hugo.yaml`. Under the `languages:` key, add:
 ```yaml
   {lang}:
     languageName: {LanguageName}
-    weight: {next available weight}
+    weight: {weight}
     title: {translatedTitle}
     params:
       description: {translatedDescription}
@@ -64,7 +64,11 @@ Edit `site/hugo.yaml`. Under the `languages:` key, add:
       status: AI
 ```
 
-Determine the next available weight by reading existing entries and incrementing.
+**Ordering**: Languages in `hugo.yaml` must be ordered by approximate number of native + L2 speakers worldwide (most speakers first). `en` is always first. When inserting the new language:
+1. Look up the current approximate global speaker count (native + L2) for the new language using a web search or knowledge lookup — do not rely on a hardcoded list.
+2. Similarly look up the speaker counts for each language already in `hugo.yaml` (other than `en`).
+3. Insert the new entry at the correct position so the list remains sorted descending by speakers.
+4. Assign `weight` values sequentially (1, 2, 3 …) reflecting this order — renumber all existing languages if necessary to keep weights contiguous and in order.
 
 ### 3b. hugo.production.yaml — Add language (disabled)
 
@@ -95,6 +99,8 @@ These files are short and should be fully translated (both front matter and body
 
 For each: copy the file, translate all human-readable string values in front matter, translate the body text. Do NOT add a `lang:` field — Hugo v0.144.0+ removed it (language is determined from the file suffix). Remove any `content:` front matter key if present.
 
+⚠️ **Aliases**: If the English source contains an `aliases:` block, every alias path MUST be prefixed with `/{lang}/`. For example `/the-kanban-guide/latest` → `/{lang}/the-kanban-guide/latest`. Aliases without the language prefix will conflict with production English routes.
+
 ### 3e. Content files — Section roots (translate front matter only, body is empty)
 
 These `_index.md` files contain only front matter (no body to translate):
@@ -105,6 +111,8 @@ These `_index.md` files contain only front matter (no body to translate):
 | `site/content/the-kanban-guide/_index.md` | `site/content/the-kanban-guide/_index.{lang}.md` |
 
 For each: copy the file, translate all human-readable string values (titles, descriptions, guide_whatis, guide_overview, guide_license, guide_comparison items, which_to_use_summary, layman_description, practitioner_description). Remove any `lang:` field if present — Hugo v0.144.0+ removed it. Keep `slug:`, `Type:`, `Layout:`, `brand:`, `weight:` unchanged.
+
+⚠️ **Aliases**: If the English source contains an `aliases:` block, every alias path MUST be prefixed with `/{lang}/`.
 
 ### 3f. Content files — Versioned guides (translate front matter ONLY, leave body EMPTY)
 
@@ -132,7 +140,7 @@ Translate in front matter: `title`, `short_title` (if present), `description`, `
 
 Do NOT translate: `date`, `version`, `type`, `mainfont`, `sansfont`, `monofont`, `sitemap`, `author`, `forked_from`.
 
-For `aliases:`, update any `/the-kanban-guide/latest` → `/{lang}/the-kanban-guide/latest` or `/{lang}/open-guide-to-kanban/latest` as appropriate.
+⚠️ **Aliases**: Every alias path MUST be prefixed with `/{lang}/`. Copy each alias from the English source and prepend `/{lang}` to it. For example `/the-kanban-guide/latest` → `/{lang}/the-kanban-guide/latest`, `/open-guide-to-kanban/latest` → `/{lang}/open-guide-to-kanban/latest`. Aliases without the language prefix will conflict with production English routes and cause routing errors.
 
 Add a `translators:` block placeholder:
 ```yaml
@@ -150,6 +158,7 @@ After creating all files, verify:
 3. `site/i18n/{lang}.yaml` exists and has all keys from `en.yaml`
 4. All expected content files exist (list them)
 5. No versioned guide file has any body content
+6. Every `aliases:` entry in every translation file starts with `/{lang}/` — flag any that do not
 
 Report the results in a clear summary table with ✅ / ❌ status for each file.
 

--- a/.agents/skills/guide.transreconcile/SKILL.md
+++ b/.agents/skills/guide.transreconcile/SKILL.md
@@ -28,7 +28,7 @@ For each language `{lang}`, the complete expected file set is:
 | Check | Location |
 |-------|----------|
 | Language entry in `site/hugo.yaml` | Under `languages.{lang}` |
-| Language entry in `site/hugo.production.yaml` | Under `languages.{lang}` with `disabled:` key |
+| Language entry in `site/hugo.production.yaml` | Under `languages.{lang}` — entry must exist; the value of `disabled:` is **not** required to be `true` (it may legitimately be `false` or absent if the language is already in production) |
 | i18n file | `site/i18n/{lang}.yaml` |
 
 ### Content files — Structural
@@ -87,6 +87,14 @@ For each existing translation content file, compare its front matter keys agains
 ### 4d. Guide body audit (versioned files only)
 For versioned guide files (`index.{lang}.md` inside version-numbered folders), check that the body (content after the closing `---`) is empty or contains only whitespace. If the body has content, flag it as a potential accidental copy of the English guide text.
 
+### 4e. Aliases audit
+For every translation content file that exists, inspect its `aliases:` front matter block (if present). Every alias path MUST begin with `/{lang}/`. Flag any alias that starts with `/` but does NOT start with `/{lang}/` as a **bad alias** — these will shadow production English routes and cause routing errors.
+
+Example of a bad alias: `/the-kanban-guide/latest` in `index.ja.md` — should be `/ja/the-kanban-guide/latest`.
+
+### 4f. Language ordering audit
+Read all non-English language entries in `site/hugo.yaml`. Look up the approximate global speaker count (native + L2) for each language via a web search or knowledge lookup. Verify that the entries are ordered descending by speaker count and that `weight` values are sequential starting from 1 (after `en`). Flag any language that is out of order or has a non-sequential weight.
+
 ## Step 5 — Report
 
 Produce a structured report:
@@ -116,6 +124,8 @@ Produce a structured report:
 - {N} i18n keys missing
 - {N} files with `lang` still set to `en`
 - {N} versioned guide files with unexpected body content
+- {N} aliases missing `/{lang}/` prefix
+- Languages out of speaker-count order in `hugo.yaml`: {list or "None"}
 ```
 
 Use ✅ for complete, ❌ for missing, ⚠️ for present but with issues.
@@ -123,6 +133,12 @@ Use ✅ for complete, ❌ for missing, ⚠️ for present but with issues.
 ## Step 6 — Fix Mode
 
 If mode is `fix`, after reporting, create or repair each identified issue:
+
+**For missing `hugo.production.yaml` entry**: Add the language entry under `languages:` in `site/hugo.production.yaml`. Because reconcile mode is used for languages that may already be in some stage of deployment, add it **without** forcing `disabled: true` — use `disabled: false` as the default so the language remains accessible:
+```yaml
+  {lang}:
+    disabled: false
+```
 
 **For missing files**: Follow the same creation rules as the `guide.transcreate` skill:
 - Structural files: translate front matter and body from English source
@@ -138,6 +154,10 @@ If mode is `fix`, after reporting, create or repair each identified issue:
 **For `lang:` present in any file**: Remove the `lang:` field entirely — Hugo v0.144.0+ removed it. Hugo determines language from the file suffix. Do not replace it with another value.
 
 **For missing front matter keys**: Add the key with the English value as placeholder followed by a `# TODO: translate` comment.
+
+**For bad aliases (missing `/{lang}/` prefix)**: Replace each offending alias by prepending `/{lang}` to it. For example `/the-kanban-guide/latest` → `/{lang}/the-kanban-guide/latest`.
+
+**For language ordering issues**: Look up the global speaker counts for all non-English languages in `hugo.yaml`, re-sort the language entries descending by speaker count, and reassign `weight` values sequentially (1, 2, 3 … after `en`).
 
 **NEVER**:
 - Add body content to versioned guide files

--- a/.agents/skills/guide.transstatus/SKILL.md
+++ b/.agents/skills/guide.transstatus/SKILL.md
@@ -45,6 +45,10 @@ For each language `{lang}`, check whether each expected scaffolding file exists:
 - `site/content/open-guide-to-kanban/{v}/index.{lang}.md`
 - `site/content/the-kanban-guide/{v}/index.{lang}.md`
 
+**Aliases check** — for every translation file that exists, scan its `aliases:` front matter block (if any). Flag any alias that starts with `/` but does NOT start with `/{lang}/` as a bad alias. These shadow production English routes.
+
+**Language ordering check** — look up the approximate global speaker count (native + L2) for each non-English language in `hugo.yaml` via a web search or knowledge lookup. Verify the entries are ordered descending by speaker count and that `weight` values are sequential. Flag any that are out of order.
+
 ## Step 4 — Check Guide Body Status
 
 For each versioned guide file that **exists**, read it and check whether the body (all content after the closing `---` of the front matter) contains meaningful text (more than whitespace/blank lines).
@@ -64,21 +68,23 @@ Output a summary table followed by a detail section and action plan.
 ```
 ## Translation Status Dashboard
 
-| Language | Code | Live? | Scaffolding | Guide Bodies |
-|----------|------|-------|-------------|--------------|
-| Japanese | ja | ✅ | ✅ Complete | ✅ All translated |
-| Spanish (Latin America) | es-419 | ❌ | ⚠️ 2 missing | ⬜ OGK 2025.7 empty, ✅ TKG 2025.5 |
-| Minionese | min | ❌ | ✅ Complete | ⬜ All empty |
+| Language | Code | Live? | Scaffolding | Aliases | Order | Guide Bodies |
+|----------|------|-------|-------------|---------|-------|---------------|
+| Japanese | ja | ✅ | ✅ Complete | ✅ OK | ✅ OK | ✅ All translated |
+| Spanish (Latin America) | es-419 | ❌ | ⚠️ 2 missing | ⚠️ 1 bad alias | ⚠️ Out of order | ⬜ OGK 2025.7 empty, ✅ TKG 2025.5 |
+| Minionese | min | ❌ | ✅ Complete | ✅ OK | ✅ OK | ⬜ All empty |
 ```
 
 **Column definitions:**
 - **Live?** — enabled in production (`disabled: false` or no entry in `hugo.production.yaml`)
 - **Scaffolding** — all config + structural files present
+- **Aliases** — all `aliases:` entries in translation files are prefixed with `/{lang}/`
+- **Order** — language is in the correct position in `hugo.yaml` sorted by global speaker count (descending), with sequential `weight`
 - **Guide Bodies** — whether versioned guide bodies are translated or empty
 
 ### Detail section
 
-For any language with issues (missing scaffolding files or empty bodies), list exactly what is missing or empty.
+For any language with issues (missing scaffolding files, bad aliases, ordering problems, or empty bodies), list exactly what is missing, wrong, or empty. Bad aliases should list the file and the offending alias value. Ordering issues should show the current order vs the expected order.
 
 ### Action plan
 


### PR DESCRIPTION
This pull request updates the translation and reconciliation skills for Hugo-based multilingual sites to enforce stricter rules for language ordering and alias handling, and to improve reporting and remediation for common issues. The changes ensure that language entries are ordered by global speaker count, all aliases are properly prefixed, and that reporting and auto-fixing are more comprehensive.

**Language ordering and weighting:**
- Language entries in `site/hugo.yaml` must now be ordered by descending global speaker count (native + L2), with `en` always first. All `weight` values must be sequential and reflect this order, requiring renumbering when changes are made. [[1]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bL59-R71) [[2]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R90-R97) [[3]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R137-R142) [[4]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R158-R161) [[5]](diffhunk://#diff-016acfdd9ca8c4bcf371d3945ff5777dfbeffdc3b688d32b8e01f0d7805cad41R48-R51)

**Alias prefixing and validation:**
- Every `aliases:` entry in translation files must be prefixed with `/{lang}/`. The documentation, validation, and auto-fix logic have been updated to enforce this strictly and flag or repair any aliases that do not conform. [[1]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bR102-R103) [[2]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bR115-R116) [[3]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bL135-R143) [[4]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bR161) [[5]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R90-R97) [[6]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R127-R128) [[7]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R158-R161) [[8]](diffhunk://#diff-016acfdd9ca8c4bcf371d3945ff5777dfbeffdc3b688d32b8e01f0d7805cad41R48-R51) [[9]](diffhunk://#diff-016acfdd9ca8c4bcf371d3945ff5777dfbeffdc3b688d32b8e01f0d7805cad41L67-R87)

**Reporting and dashboard improvements:**
- The status and reconciliation reports now include new columns and summary counts for alias prefixing and language order, and provide more detailed diagnostics and action plans for these issues. [[1]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R127-R128) [[2]](diffhunk://#diff-016acfdd9ca8c4bcf371d3945ff5777dfbeffdc3b688d32b8e01f0d7805cad41L67-R87)

**Reconciliation and auto-fix enhancements:**
- When fixing issues, the skills now automatically re-sort languages and reassign weights, and repair bad aliases by prepending the correct prefix. The logic for adding entries to `hugo.production.yaml` is clarified to avoid forcing `disabled: true`. [[1]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R137-R142) [[2]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44R158-R161)

**Documentation clarity:**
- The guides for both transcreation and reconciliation have been updated with clearer instructions, more explicit examples, and warnings about the impact of misordered languages and bad aliases. [[1]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bL59-R71) [[2]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bR102-R103) [[3]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bR115-R116) [[4]](diffhunk://#diff-e18d2d075419df83dc56f071a9a1801dc2443626ec6dbae7d3a484f1694d027bL135-R143) [[5]](diffhunk://#diff-41d02272929767ed01f4458ff5b3c545e36badb29e00d23cc18b32ec33021b44L31-R31)

These changes collectively improve the reliability and maintainability of multilingual site management by enforcing best practices and automating error detection and correction.