### PR TITLE
Enable French language support in production config

### DIFF
--- a/site/hugo.production.yaml
+++ b/site/hugo.production.yaml
@@ -17,7 +17,7 @@ languages:
   es-419:
     disabled: true
   fr:
-    disabled: true
+    disabled: false
   ja:
     disabled: false
   es-ES:


### PR DESCRIPTION
This pull request makes a small change to the language configuration by enabling the French (`fr`) language in the `site/hugo.production.yaml` file.